### PR TITLE
Fix webhookShell() deadlock when child output exceeds the pipe buffer

### DIFF
--- a/Shared/Webhooks.swift
+++ b/Shared/Webhooks.swift
@@ -186,10 +186,17 @@ private func webhookShell(_ executable: String, _ args: [String]) -> String {
     p.arguments = args
     let pipe = Pipe()
     p.standardOutput = pipe
-    p.standardError  = Pipe()
+    // nullDevice, not Pipe(): an unread stderr pipe can fill and block the child just as
+    // stdout can, and nothing here ever reads it.
+    p.standardError  = FileHandle.nullDevice
     guard (try? p.run()) != nil else { return "" }
+    // Drain BEFORE waiting. readDataToEndOfFile() returns at EOF and keeps the pipe empty
+    // while the child runs; waiting first deadlocks as soon as the child writes more than
+    // the ~64 KiB pipe buffer, because it blocks in write() and can then never exit.
+    // Hit in the wild by `profiles show` on an Intune-managed Mac (~75 KB of output).
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
     p.waitUntilExit()
-    return String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+    return String(data: data, encoding: .utf8) ?? ""
 }
 
 // MARK: - Main Entry Point


### PR DESCRIPTION
Fixes the `webhookShell()` deadlock in #8 - on Intune Macs `profiles show` emits ~75 KB, overflows the pipe buffer, and the child and parent wait on each other permanently, taking the scheduler's serial work queue down with them.

The change is the read/wait ordering: drain the pipe first, then `waitUntilExit()`. Also switches stderr from an unread `Pipe()` to `FileHandle.nullDevice`, since an unread stderr pipe can block the child in exactly the same way.

Verified on real binaries, not just in the model. `patcher testWebhook` goes through `collectWebhookDeviceInfo()` (`Patcher.swift:764`), so it exercises the same path:

```
1.0.0 as shipped : HUNG (killed at 25s)
same tree + fix  : completed in 1s
```

The fixed build still detects the MDM correctly, so it's reading the whole 75 KB and matching rather than just failing faster. `patcher` and `patcherscheduler` both build clean under Xcode 27.0 (27A5194q).

No test, deliberately - two reasons. `patcherTests.swift` states its own scope in the header as "Tests for pure patcher logic — no process launching, no disk I/O", and `webhookShell` is private, so a process-launching test would cut against that file's convention. Separately, the `patcherTests` target doesn't currently compile for me: 78 `cannot find ... in scope` errors on `UpdateStatus`, `validateLabelRequiredKeys` and friends. That reproduces identically against unmodified `main`, so it's not from this change - looks like target membership for the patcher sources. Happy to add a test if you'd rather have one, and happy to file the target issue separately if it's news to you.

The runnable repro lives in #8.
