### PR TITLE
Update patcherscheduler to always stage before apply phase

### DIFF
--- a/Shared/Constants.swift
+++ b/Shared/Constants.swift
@@ -35,6 +35,10 @@ struct AppConstants {
 
     static let patcherXPCServiceName = "com.gilburns.patcher.xpc"
 
+    /// patcherscheduler's fixed timer cadence — shared so scheduling logic can reason
+    /// about "next cycle" without duplicating the literal used to schedule the timer.
+    static let schedulerCycleIntervalSeconds: TimeInterval = 600
+
     static let applicationSupportURL: URL = {
         FileManager.default.urls(for: .libraryDirectory, in: .localDomainMask)
             .first?

--- a/patcherscheduler/PatcherScheduler.swift
+++ b/patcherscheduler/PatcherScheduler.swift
@@ -43,13 +43,25 @@ struct PatcherScheduler {
                            !FileManager.default.fileExists(atPath: AppConstants.swiftDialogBinaryURL.path)
         let metadataDue  = shouldRunMetadataSync(state: state, now: now)
 
+        // ── Apply lookahead ────────────────────────────────────────────────────
+        // If apply's schedule condition would already be satisfied one cycle from now,
+        // and discovered items still need downloading, stage them a cycle early so
+        // apply runs as a full pass instead of a partial one once its window opens.
+        let applyDueNextCycle = resolveApplySchedule(
+            state: state, now: now.addingTimeInterval(AppConstants.schedulerCycleIntervalSeconds)
+        ) != nil
+        let stageCatchUpNeeded = !stageDue && applyDueNextCycle && hasUnstagedPendingUpdates()
+        if stageCatchUpNeeded {
+            Logger.log("ℹ️ Stage: apply due next cycle with unstaged updates — staging early.")
+        }
+
         // ── Internet connectivity check ───────────────────────────────────────
         // Performed once, only when at least one phase requires the network.
         // Verifies real internet access AND rules out captive-portal situations
         // by confirming the response body from captive.apple.com says "Success".
         // apply is intentionally excluded — it runs from already-staged files.
         // lightScan is included because scanSingleLabel (called on hits) needs the network.
-        let networkPhaseDue = scanDue || lightScanDue || checkDue || stageDue || dialogDue || metadataDue
+        let networkPhaseDue = scanDue || lightScanDue || checkDue || stageDue || stageCatchUpNeeded || dialogDue || metadataDue
         let networkOK: Bool
         if networkPhaseDue {
             networkOK = isInternetAvailable()
@@ -136,9 +148,11 @@ struct PatcherScheduler {
 
         // ── Stage ─────────────────────────────────────────────────────────────
         // Same interval as check (default 24 h). Downloads pending updates.
+        // Also runs early (stageCatchUpNeeded) when apply is due next cycle and
+        // items are still unstaged, so apply doesn't run a partial pass.
         // Check display assertions — a download can saturate bandwidth during a
         // presentation. Focus/DND alone doesn't block a silent background download.
-        if stageDue && networkOK {
+        if (stageDue || stageCatchUpNeeded) && networkOK {
             let bypassFocus = isFocusDeadlineReached(state: state, now: now) || isHardDeadlineReached(state: state, now: now)
             if prefs.focusCheckEnabled && !bypassFocus,
                let presenter = FocusDetector.activeDisplayAssertion(ignoredProcesses: prefs.focusIgnoredProcesses) {
@@ -184,6 +198,23 @@ struct PatcherScheduler {
                 let daysPending = state.firstPendingDate.map {
                     Calendar.current.dateComponents([.day], from: $0, to: now).day ?? 0
                 } ?? 0
+
+                // Safety net: the apply lookahead normally stages everything a cycle early,
+                // but a new item can be discovered this same cycle, or a large download from
+                // the lookahead pass may still be in flight. Catch up here so apply still runs
+                // as a full pass rather than silently skipping unstaged items.
+                if hasUnstagedPendingUpdates() {
+                    if isInternetAvailable() {
+                        Logger.log("⚠️ Apply: unstaged updates found — staging before apply to avoid a partial pass.")
+                        writeActivePhase("stage")
+                        runSubcommand("stage")
+                        clearActivePhase()
+                        state.lastStageDate = now
+                        dirty = true
+                    } else {
+                        Logger.log("⚠️ Apply: unstaged updates found but no internet connectivity — proceeding with apply for what's already staged.")
+                    }
+                }
 
                 // Silent pre-pass: install anything whose blocking process isn't running.
                 // Skipped items are not counted as deferrals.
@@ -824,6 +855,45 @@ struct PatcherScheduler {
             if hasStagedFile { return true }
         }
         return false
+    }
+
+    /// Returns true when a discovered item needs updating (updateStatus == "updateRequired")
+    /// but has no staged file waiting in Cache/ yet — i.e. apply would have to skip it today.
+    /// Used to decide whether to run a catch-up stage pass ahead of, or immediately before, apply.
+    private func hasUnstagedPendingUpdates() -> Bool {
+        let fm = FileManager.default
+
+        let stagedLabels: Set<String> = {
+            guard let labelDirs = try? fm.contentsOfDirectory(
+                at: AppConstants.patcherCacheFolderURL, includingPropertiesForKeys: [.isDirectoryKey]
+            ) else { return [] }
+            return Set(labelDirs.compactMap { labelDir -> String? in
+                var isDir: ObjCBool = false
+                guard fm.fileExists(atPath: labelDir.path, isDirectory: &isDir), isDir.boolValue else { return nil }
+                let contents = (try? fm.contentsOfDirectory(
+                    at: labelDir, includingPropertiesForKeys: nil
+                )) ?? []
+                let hasStagedFile = contents.contains {
+                    $0.lastPathComponent != "metadata.json" && $0.lastPathComponent != "history.json"
+                }
+                return hasStagedFile ? labelDir.lastPathComponent : nil
+            })
+        }()
+
+        guard let plists = try? fm.contentsOfDirectory(
+            at: AppConstants.patcherDiscoveredFolderURL, includingPropertiesForKeys: nil
+        ) else { return false }
+
+        return plists.contains { url in
+            guard url.pathExtension == "plist" else { return false }
+            let label = url.deletingPathExtension().lastPathComponent
+            guard !stagedLabels.contains(label),
+                  let data = try? Data(contentsOf: url),
+                  let dict = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any],
+                  let status = dict["updateStatus"] as? String
+            else { return false }
+            return status == "updateRequired"
+        }
     }
 
 

--- a/patcherscheduler/main.swift
+++ b/patcherscheduler/main.swift
@@ -74,7 +74,7 @@ Logger.log("ℹ️ XPC listener active on '\(AppConstants.patcherXPCServiceName)
 
 // MARK: - Scheduled cycle timer
 
-let cycleInterval: TimeInterval = 600
+let cycleInterval: TimeInterval = AppConstants.schedulerCycleIntervalSeconds
 
 let cycleTimer: DispatchSourceTimer = {
     let t = DispatchSource.makeTimerSource(queue: .global())


### PR DESCRIPTION
 Shared/Constants.swift — added AppConstants.schedulerCycleIntervalSeconds (600s), the single source of truth for the timer cadence, now also used by main.swift's timer instead of a duplicated literal.

  PatcherScheduler.swift:
  1. New hasUnstagedPendingUpdates() — reads Discovered/*.plist for updateStatus == "updateRequired" items that have no staged file in Cache/ yet (same "staged" definition already used by hasStagedUpdates()).
  2. Lookahead: each cycle, evaluates resolveApplySchedule(state:now:) one cycle into the future. If apply would be due next tick and unstaged items exist, it sets stageCatchUpNeeded and folds that into the existing stage block's trigger condition (stageDue ||  stageCatchUpNeeded) and into the connectivity-check gate — so it reuses all the existing Focus/network/firstPendingDate logic in that block rather than duplicating it.
  3. Fallback safety net: right before the quiet/interactive apply calls, if hasUnstagedPendingUpdates() is still true (new item discovered same cycle, or a large lookahead download still in flight), it runs a synchronous catch-up stage first — so apply never silently skips pending items. It checks connectivity itself and just proceeds with apply-of-what's-staged if offline, logging that fact.

  In the common case, the lookahead stages everything a full cycle ahead of the apply window opening, so apply runs with zero added delay. The fallback only kicks in for the rarer edge cases, and only delays apply by however long that catch-up stage takes.