### PR TITLE
Additional filtering of mdfind results to discard virtual or trashed apps

### DIFF
--- a/patcher/PatcherCore.swift
+++ b/patcher/PatcherCore.swift
@@ -1220,8 +1220,18 @@ private func runMdfind(appWithExtension: String, ignoreExternalVolumes: Bool = f
     return output.components(separatedBy: "\0").filter { path in
         guard !path.isEmpty else { return false }
         if ignoreExternalVolumes && path.hasPrefix("/Volumes/") { return false }
+        if isIgnoredScanPath(path) { return false }
         return !path.hasPrefix("/Library/") && !path.hasPrefix("/System/")
     }
+}
+
+/// Paths that mdfind may surface but should never be treated as real installs
+/// (Trash contents, and Parallels/Virtual Machines shared Applications folders).
+private func isIgnoredScanPath(_ path: String) -> Bool {
+    if path.contains("/.Trash/") { return true }
+    if path.contains("/Applications (Parallels)/") { return true }
+    if path.contains("/Applications (Virtual Machines)/") { return true }
+    return false
 }
 
 


### PR DESCRIPTION
Added a filter in runMdfind (patcher/PatcherCore.swift:1201) so any app path mdfind surfaces under .Trash, /Applications (Parallels)/, or /Applications (Virtual Machines)/ is silently discarded. Using /.Trash/ as a substring check means it catches both root-level .Trash and any per-user /Users/<username>/.Trash path automatically.