### PR TITLE
Implemented non-production label filtering

### DIFF
--- a/MDM Examples/com.gilburns.patcher.plist
+++ b/MDM Examples/com.gilburns.patcher.plist
@@ -32,6 +32,10 @@
 	<false/>
 	<key>IgnoredLabels</key>
 	<string>bbedit brave firefox_da firefox_intl firefox firefoxesr_intl firefoxesr firefoxpkg_intl googlechrome* microsoft* nudge* renew-noagent thunderbird_intl thunderbirdesr zoomclient zoomgov zulujdk*</string>
+	<key>IgnoreNonProductionLabels</key>
+	<true/>
+	<key>NonProductionLabelSuffixes</key>
+	<string>beta canary dev</string>
 	<key>InstallomatorGitHubAccount</key>
 	<string>Installomator</string>
 	<key>InstallomatorGitHubBranch</key>

--- a/Shared/Preferences.swift
+++ b/Shared/Preferences.swift
@@ -159,6 +159,26 @@ struct Preferences {
         return value.split(separator: " ").map(String.init).filter { !$0.isEmpty }
     }
 
+    /// When true, non-production label variants (labels whose name ends with one of
+    /// `NonProductionLabelSuffixes`) are automatically added to the ignored list, but only
+    /// when a production label of the same base name also exists.
+    /// E.g. with the default suffixes, "microsoftedgebeta" and "microsoftedgedev" are ignored
+    /// because "microsoftedge" also exists as a label; a label like "figma" with no
+    /// suffix is untouched, and a hypothetical "somethingbeta" is left alone if "something"
+    /// does not also exist as a label.
+    /// Default is true. Set to false to manage non-production labels yourself via IgnoredLabels.
+    var ignoreNonProductionLabels: Bool {
+        prefs["IgnoreNonProductionLabels"] as? Bool ?? true
+    }
+
+    /// Space-separated list of suffixes that mark a label as a non-production variant of a
+    /// base label (e.g. "beta canary dev"). Only used when IgnoreNonProductionLabels is true.
+    /// Defaults to "beta canary dev".
+    var nonProductionLabelSuffixes: [String] {
+        let value = prefs["NonProductionLabelSuffixes"] as? String ?? "beta canary dev"
+        return value.split(separator: " ").map(String.init).filter { !$0.isEmpty }
+    }
+
     /// Space-separated list of label name patterns that are required.
     /// Does NOT Support `*` and `?` wildcards (e.g. `"google* microsoft*"`).
     var requiredLabels: [String] {

--- a/patcher/PatcherCore.swift
+++ b/patcher/PatcherCore.swift
@@ -288,8 +288,12 @@ func scanAppsForUpdates(progressHandler: ((Int, Int, String) -> Void)? = nil) {
     let preferences = Preferences()
     Logger.log("📋 Preferences source: \(preferences.source)")
 
+    // Retrieve and filter ".sh" files, merging managed label overrides/additions
+    let shFiles = buildLabelFileList()
+
     var ignoredPatterns = preferences.ignoredLabels
     appendManagedAppLabels(to: &ignoredPatterns, preferences: preferences)
+    appendNonProductionLabels(to: &ignoredPatterns, allLabels: shFiles.map { $0.deletingPathExtension().lastPathComponent }, preferences: preferences)
     if !ignoredPatterns.isEmpty {
         Logger.log("⏭️ Ignored label patterns: \(ignoredPatterns.joined(separator: ", "))")
     }
@@ -312,9 +316,6 @@ func scanAppsForUpdates(progressHandler: ((Int, Int, String) -> Void)? = nil) {
     }
 
     do {
-        // Retrieve and filter ".sh" files, merging managed label overrides/additions
-        let shFiles = buildLabelFileList()
-
         guard !shFiles.isEmpty else {
             Logger.log("❌ No label files found — nothing to scan. Add managed labels or enable Installomator labels.")
             return
@@ -535,6 +536,7 @@ func checkDiscoveredAppsForUpdates(progressHandler: ((Int, Int, String, String) 
 
     var ignoredPatterns = preferences.ignoredLabels
     appendManagedAppLabels(to: &ignoredPatterns, preferences: preferences)
+    appendNonProductionLabels(to: &ignoredPatterns, allLabels: buildLabelFileList().map { $0.deletingPathExtension().lastPathComponent }, preferences: preferences)
     if !ignoredPatterns.isEmpty {
         Logger.log("⏭️ Ignored label patterns: \(ignoredPatterns.joined(separator: ", "))")
     }
@@ -757,6 +759,34 @@ private func appendManagedAppLabels(to patterns: inout [String], preferences: Pr
         let labels = AppConstants.googleDriveLabels.split(separator: " ").map(String.init)
         patterns.append(contentsOf: labels)
         Logger.log("☁️ Google Drive MDM-managed — appending \(labels.count) labels to ignored list")
+    }
+}
+
+/// Appends non-production label variants (e.g. "beta", "canary", "dev" suffixed labels) to
+/// `patterns` when `IgnoreNonProductionLabels` is enabled. A label is only treated as a
+/// non-production variant when a production label of the same base name also exists in
+/// `allLabels` — e.g. "microsoftedgebeta" and "microsoftedgedev" are ignored because
+/// "microsoftedge" is also present, but a label like "figma" is untouched, and a
+/// hypothetical "somethingbeta" is left alone if "something" is not also a known label.
+private func appendNonProductionLabels(to patterns: inout [String], allLabels: [String], preferences: Preferences) {
+    guard preferences.ignoreNonProductionLabels else { return }
+    let suffixes = preferences.nonProductionLabelSuffixes
+    guard !suffixes.isEmpty else { return }
+
+    let labelSet = Set(allLabels)
+    var nonProductionLabels: [String] = []
+    for label in allLabels {
+        for suffix in suffixes where label.count > suffix.count && label.hasSuffix(suffix) {
+            let baseName = String(label.dropLast(suffix.count))
+            if labelSet.contains(baseName) {
+                nonProductionLabels.append(label)
+                break
+            }
+        }
+    }
+    if !nonProductionLabels.isEmpty {
+        patterns.append(contentsOf: nonProductionLabels)
+        Logger.log("🧪 Non-production label variants — appending \(nonProductionLabels.count) labels to ignored list: \(nonProductionLabels.sorted().joined(separator: ", "))")
     }
 }
 


### PR DESCRIPTION
Two new preferences:
ignoreNonProductionLabels: default true
nonProductionLabelSuffixes: default "beta canary dev"

For each label, it checks whether it ends with one of the configured suffixes and whether stripping that suffix yields another label name that also exists in the full label catalog. Only then is it appended to the ignored patterns (e.g. microsoftedgebeta/microsoftedgedev are ignored because microsoftedge exists