### PR TITLE
Added PreferPkgLabels

### DIFF
--- a/MDM Examples/com.gilburns.patcher.plist
+++ b/MDM Examples/com.gilburns.patcher.plist
@@ -36,6 +36,8 @@
 	<true/>
 	<key>NonProductionLabelSuffixes</key>
 	<string>beta canary dev</string>
+	<key>PreferPkgLabels</key>
+	<true/>
 	<key>InstallomatorGitHubAccount</key>
 	<string>Installomator</string>
 	<key>InstallomatorGitHubBranch</key>

--- a/Shared/Preferences.swift
+++ b/Shared/Preferences.swift
@@ -179,6 +179,15 @@ struct Preferences {
         return value.split(separator: " ").map(String.init).filter { !$0.isEmpty }
     }
 
+    /// When a label and its "pkg"-suffixed counterpart both exist (e.g. "bbedit" and
+    /// "bbeditpkg"), they deliver the same app via different installer mechanisms and only
+    /// one should ever be active. When true (the default), the pkg-suffixed label is
+    /// preferred and the non-pkg label is added to the ignored list. When false, the non-pkg
+    /// label is preferred and the pkg-suffixed label is ignored instead.
+    var preferPkgLabels: Bool {
+        prefs["PreferPkgLabels"] as? Bool ?? true
+    }
+
     /// Space-separated list of label name patterns that are required.
     /// Does NOT Support `*` and `?` wildcards (e.g. `"google* microsoft*"`).
     var requiredLabels: [String] {

--- a/patcher/PatcherCore.swift
+++ b/patcher/PatcherCore.swift
@@ -290,10 +290,12 @@ func scanAppsForUpdates(progressHandler: ((Int, Int, String) -> Void)? = nil) {
 
     // Retrieve and filter ".sh" files, merging managed label overrides/additions
     let shFiles = buildLabelFileList()
+    let allLabelNames = shFiles.map { $0.deletingPathExtension().lastPathComponent }
 
     var ignoredPatterns = preferences.ignoredLabels
     appendManagedAppLabels(to: &ignoredPatterns, preferences: preferences)
-    appendNonProductionLabels(to: &ignoredPatterns, allLabels: shFiles.map { $0.deletingPathExtension().lastPathComponent }, preferences: preferences)
+    appendNonProductionLabels(to: &ignoredPatterns, allLabels: allLabelNames, preferences: preferences)
+    appendPkgLabelDuplicates(to: &ignoredPatterns, allLabels: allLabelNames, preferences: preferences)
     if !ignoredPatterns.isEmpty {
         Logger.log("⏭️ Ignored label patterns: \(ignoredPatterns.joined(separator: ", "))")
     }
@@ -534,9 +536,12 @@ func checkDiscoveredAppsForUpdates(progressHandler: ((Int, Int, String, String) 
     let preferences = Preferences()
     Logger.log("📋 Preferences source: \(preferences.source)")
 
+    let allLabelNames = buildLabelFileList().map { $0.deletingPathExtension().lastPathComponent }
+
     var ignoredPatterns = preferences.ignoredLabels
     appendManagedAppLabels(to: &ignoredPatterns, preferences: preferences)
-    appendNonProductionLabels(to: &ignoredPatterns, allLabels: buildLabelFileList().map { $0.deletingPathExtension().lastPathComponent }, preferences: preferences)
+    appendNonProductionLabels(to: &ignoredPatterns, allLabels: allLabelNames, preferences: preferences)
+    appendPkgLabelDuplicates(to: &ignoredPatterns, allLabels: allLabelNames, preferences: preferences)
     if !ignoredPatterns.isEmpty {
         Logger.log("⏭️ Ignored label patterns: \(ignoredPatterns.joined(separator: ", "))")
     }
@@ -787,6 +792,27 @@ private func appendNonProductionLabels(to patterns: inout [String], allLabels: [
     if !nonProductionLabels.isEmpty {
         patterns.append(contentsOf: nonProductionLabels)
         Logger.log("🧪 Non-production label variants — appending \(nonProductionLabels.count) labels to ignored list: \(nonProductionLabels.sorted().joined(separator: ", "))")
+    }
+}
+
+/// Appends one label of each pkg/non-pkg label pair to `patterns`, keeping only the label
+/// preferred by `PreferPkgLabels`. E.g. "bbedit" and "bbeditpkg" both exist as separate
+/// Installomator labels delivering the same app via different installer mechanisms — only one
+/// should ever be active. When `PreferPkgLabels` is true (default) the non-pkg label
+/// ("bbedit") is ignored in favor of the pkg label; when false, the pkg label is ignored
+/// in favor of the non-pkg label.
+private func appendPkgLabelDuplicates(to patterns: inout [String], allLabels: [String], preferences: Preferences) {
+    let pkgSuffix = "pkg"
+    let labelSet = Set(allLabels)
+    var duplicateLabels: [String] = []
+    for label in allLabels where label.count > pkgSuffix.count && label.hasSuffix(pkgSuffix) {
+        let baseName = String(label.dropLast(pkgSuffix.count))
+        guard labelSet.contains(baseName) else { continue }
+        duplicateLabels.append(preferences.preferPkgLabels ? baseName : label)
+    }
+    if !duplicateLabels.isEmpty {
+        patterns.append(contentsOf: duplicateLabels)
+        Logger.log("📦 Pkg/non-pkg label duplicates — appending \(duplicateLabels.count) labels to ignored list: \(duplicateLabels.sorted().joined(separator: ", "))")
     }
 }
 


### PR DESCRIPTION
New preference:
PreferPkgLabels (Defaults to true)

For every label ending in pkg, checks if the base name (suffix stripped) also exists as a label. If so, appends whichever side isn't preferred to the ignored patterns. (bbedit when true, bbeditpkg when false)

There's no real reason to run both, so this is not able to be disabled. Adding one to RequiredLabels would be the way to work around and have patcher process both, but why? 😁