### PR TITLE
Split deferral counts

### DIFF
--- a/PatcherMenu/MenuStatusView.swift
+++ b/PatcherMenu/MenuStatusView.swift
@@ -396,7 +396,7 @@ struct MenuStatusView: View {
                 HStack(spacing: 4) {
                     Image(systemName: "arrow.uturn.backward")
                         .frame(width: 14)
-                    Text("Deferred \(vm.deferralCount) time\(vm.deferralCount == 1 ? "" : "s") (Includes auto-deferrals)")
+                    Text(vm.deferralCountText)
                         .font(.caption)
                 }
                 .foregroundStyle(.secondary)

--- a/PatcherMenu/PatcherMenuViewModel.swift
+++ b/PatcherMenu/PatcherMenuViewModel.swift
@@ -37,6 +37,28 @@ final class PatcherMenuViewModel: ObservableObject {
     struct DeferralStateData: Codable {
         var expiryDate: Date?
         var count: Int = 0
+        var userDeferralCount: Int = 0
+        var timedOutDeferralCount: Int = 0
+        var blockingProcessDeferralCount: Int = 0
+
+        private enum CodingKeys: String, CodingKey {
+            case expiryDate, count, userDeferralCount, timedOutDeferralCount, blockingProcessDeferralCount
+        }
+
+        // Lenient decode — the split counters were added after the first releases,
+        // so older deferral_state.json files won't carry them.
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            expiryDate                   = try c.decodeIfPresent(Date.self, forKey: .expiryDate)
+            count                        = try c.decodeIfPresent(Int.self, forKey: .count) ?? 0
+            userDeferralCount            = try c.decodeIfPresent(Int.self, forKey: .userDeferralCount) ?? 0
+            timedOutDeferralCount        = try c.decodeIfPresent(Int.self, forKey: .timedOutDeferralCount) ?? 0
+            blockingProcessDeferralCount = try c.decodeIfPresent(Int.self, forKey: .blockingProcessDeferralCount) ?? 0
+        }
+    }
+
+    enum DeferralCountDisplay {
+        case combined, split, userOnly
     }
 
     struct StagedPatch: Identifiable {
@@ -59,6 +81,35 @@ final class PatcherMenuViewModel: ObservableObject {
     var hasDetectedUpdates: Bool { !detectedPatches.isEmpty }
 
     var deferralCount: Int { deferralState?.count ?? schedulerState?.deferralCount ?? 0 }
+
+    /// Deferrals the user actively chose in the prompt.
+    var userDeferralCount: Int { deferralState?.userDeferralCount ?? 0 }
+
+    /// Auto-deferrals: prompt timer time-outs plus blocking-process skips.
+    var autoDeferralCount: Int {
+        (deferralState?.timedOutDeferralCount ?? 0) + (deferralState?.blockingProcessDeferralCount ?? 0)
+    }
+
+    var deferralCountDisplay: DeferralCountDisplay {
+        switch preferences.menuDeferralCountDisplay.lowercased() {
+        case "split":    return .split
+        case "useronly": return .userOnly
+        default:         return .combined
+        }
+    }
+
+    /// The deferral-count line shown in the popover, honoring `MenuDeferralCountDisplay`.
+    var deferralCountText: String {
+        func times(_ n: Int) -> String { "\(n) time\(n == 1 ? "" : "s")" }
+        switch deferralCountDisplay {
+        case .combined:
+            return "Deferred \(times(deferralCount)) (includes auto-deferrals)"
+        case .split:
+            return "Deferred \(times(userDeferralCount)) by you · \(times(autoDeferralCount)) automatically"
+        case .userOnly:
+            return "Deferred \(times(userDeferralCount)) by you"
+        }
+    }
 
     /// Approximate label for when the next apply prompt will appear.
     /// Coarsely bucketed — no exact countdown — because the prompt fires on the next

--- a/Shared/DeferralState.swift
+++ b/Shared/DeferralState.swift
@@ -11,17 +11,56 @@
 
 import Foundation
 
+/// Distinguishes how a deferral was initiated.
+enum DeferralKind {
+    /// The user actively clicked "Defer" in the prompt.
+    case user
+    /// The prompt's countdown timer expired without the user choosing.
+    case timedOut
+}
+
 struct DeferralState: Codable {
 
     /// Expiry of the most recently recorded deferral. nil = no active deferral.
     var expiryDate: Date?
 
-    /// Running total of deferrals recorded in the current apply cycle.
+    /// Running total of deferrals recorded in the current apply cycle
+    /// (user-initiated + timed-out + blocking-process + any other source).
     /// Reset to 0 when the deferral is cleared after a successful apply.
     var count: Int = 0
 
+    /// Deferrals in the current apply cycle where the user actively clicked "Defer".
+    var userDeferralCount: Int = 0
+
+    /// Deferrals in the current apply cycle where the prompt's countdown timer
+    /// expired without the user making a choice.
+    var timedOutDeferralCount: Int = 0
+
+    /// Deferrals in the current apply cycle caused by a label being skipped because
+    /// its blocking process was still running (the user never saw a prompt).
+    var blockingProcessDeferralCount: Int = 0
+
     private static let stateURL: URL = AppConstants.patcherConfigFolderURL
         .appendingPathComponent("deferral_state.json")
+
+    // MARK: Codable
+
+    init() {}
+
+    private enum CodingKeys: String, CodingKey {
+        case expiryDate, count, userDeferralCount, timedOutDeferralCount, blockingProcessDeferralCount
+    }
+
+    /// Lenient decoder — the split counters were added later, so state files
+    /// written by earlier versions won't contain them.
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        expiryDate                   = try c.decodeIfPresent(Date.self, forKey: .expiryDate)
+        count                        = try c.decodeIfPresent(Int.self, forKey: .count) ?? 0
+        userDeferralCount            = try c.decodeIfPresent(Int.self, forKey: .userDeferralCount) ?? 0
+        timedOutDeferralCount       = try c.decodeIfPresent(Int.self, forKey: .timedOutDeferralCount) ?? 0
+        blockingProcessDeferralCount = try c.decodeIfPresent(Int.self, forKey: .blockingProcessDeferralCount) ?? 0
+    }
 
     // MARK: Persistence
 
@@ -66,10 +105,15 @@ struct DeferralState: Codable {
 
     // MARK: Mutations
 
-    /// Records a new deferral for `minutes` from `now`, incrementing the count.
-    mutating func recordDeferral(minutes: Int, now: Date = Date()) {
+    /// Records a new deferral for `minutes` from `now`, incrementing the total
+    /// count and the counter for the given `kind`.
+    mutating func recordDeferral(minutes: Int, kind: DeferralKind = .user, now: Date = Date()) {
         expiryDate = now.addingTimeInterval(TimeInterval(minutes * 60))
         count += 1
+        switch kind {
+        case .user:     userDeferralCount += 1
+        case .timedOut: timedOutDeferralCount += 1
+        }
     }
 
     /// Records an automatic Focus/DND deferral for `minutes` from `now`.
@@ -78,10 +122,22 @@ struct DeferralState: Codable {
         expiryDate = now.addingTimeInterval(TimeInterval(minutes * 60))
     }
 
+    /// Records a blocking-process skip — a label was skipped during apply because its
+    /// blocking process was still running. Bumps the total and blocking-process
+    /// counters but does NOT set an expiry: the skip is retried on the next apply
+    /// cycle, not after a timer.
+    mutating func recordBlockingProcessSkip() {
+        count += 1
+        blockingProcessDeferralCount += 1
+    }
+
     /// Clears any active deferral and resets the count (call after successful apply).
     mutating func reset() {
-        expiryDate = nil
-        count      = 0
+        expiryDate                   = nil
+        count                        = 0
+        userDeferralCount            = 0
+        timedOutDeferralCount        = 0
+        blockingProcessDeferralCount = 0
     }
 }
 

--- a/Shared/Preferences.swift
+++ b/Shared/Preferences.swift
@@ -584,6 +584,18 @@ struct Preferences {
         prefs["ShowActivitySection"] as? Bool ?? true
     }
 
+    /// Controls how the deferral count is shown in the menu bar popover.
+    /// Options: combined | split | userOnly
+    ///   combined — one total covering every deferral, including auto-deferrals
+    ///              (timer time-outs and blocking-process skips). Current behavior.
+    ///   split    — two figures: deferrals the user actively chose, and auto-deferrals
+    ///              (timer time-outs + blocking-process skips) combined.
+    ///   userOnly — only the count of deferrals the user actively chose.
+    /// Defaults to "combined".
+    var menuDeferralCountDisplay: String {
+        pref("MenuDeferralCountDisplay", default: "combined")
+    }
+
     /// When true, a Quit button is shown in the menu bar popover footer.
     /// Defaults to false.
     var showQuitButton: Bool {

--- a/patcher/PatcherCore.swift
+++ b/patcher/PatcherCore.swift
@@ -1588,15 +1588,15 @@ func applyUpdates(labelFilter: String? = nil, suppressDialog: Bool = false, days
                 switch promptResult {
                 case .deferred(let minutes):
                     recordDeferralOutcome(labels: pendingLabels, result: promptResult, date: Date())
-                    deferralState.recordDeferral(minutes: minutes)
+                    deferralState.recordDeferral(minutes: minutes, kind: .user)
                     deferralState.save()
-                    Logger.log("⏸️ Apply deferred for \(formatDeferralDuration(minutes)) (deferral #\(deferralState.count)). Exiting.")
+                    Logger.log("⏸️ Apply deferred for \(formatDeferralDuration(minutes)) (deferral #\(deferralState.count), user #\(deferralState.userDeferralCount)). Exiting.")
                     return
                 case .timedOutDeferred(let minutes):
                     recordDeferralOutcome(labels: pendingLabels, result: promptResult, date: Date())
-                    deferralState.recordDeferral(minutes: minutes)
+                    deferralState.recordDeferral(minutes: minutes, kind: .timedOut)
                     deferralState.save()
-                    Logger.log("⏸️ Apply auto-deferred (timer) for \(formatDeferralDuration(minutes)) (deferral #\(deferralState.count)). Exiting.")
+                    Logger.log("⏸️ Apply auto-deferred (timer) for \(formatDeferralDuration(minutes)) (deferral #\(deferralState.count), timed-out #\(deferralState.timedOutDeferralCount)). Exiting.")
                     return
                 case .deadlineForced:
                     recordDeferralOutcome(labels: pendingLabels, result: promptResult, date: Date())
@@ -1978,9 +1978,9 @@ func applyUpdates(labelFilter: String? = nil, suppressDialog: Bool = false, days
         // installs and should not advance the deadline counter.
         if blockedSkipOccurred, !silentApply {
             var deferralState = DeferralState.load()
-            deferralState.count += 1
+            deferralState.recordBlockingProcessSkip()
             deferralState.save()
-            Logger.log("ℹ️ Blocking-process skip recorded as deferral #\(deferralState.count).")
+            Logger.log("ℹ️ Blocking-process skip recorded as deferral #\(deferralState.count) (blocking-process #\(deferralState.blockingProcessDeferralCount)).")
         }
 
         // Reset deferral only when all staged updates have been applied.

--- a/patcherschedulerTests/patcherschedulerTests.swift
+++ b/patcherschedulerTests/patcherschedulerTests.swift
@@ -128,6 +128,61 @@ struct DeferralStateTests {
         state.recordDeferral(minutes: 30)
         #expect(state.count == 3)
     }
+
+    @Test func splitCountersTrackKindSeparately() {
+        var state = DeferralState()
+        state.recordDeferral(minutes: 30, kind: .user)
+        state.recordDeferral(minutes: 30, kind: .timedOut)
+        state.recordDeferral(minutes: 30, kind: .user)
+        state.recordBlockingProcessSkip()
+        #expect(state.count == 4)
+        #expect(state.userDeferralCount == 2)
+        #expect(state.timedOutDeferralCount == 1)
+        #expect(state.blockingProcessDeferralCount == 1)
+    }
+
+    @Test func blockingProcessSkipDoesNotSetExpiry() {
+        var state = DeferralState()
+        state.recordBlockingProcessSkip()
+        #expect(state.expiryDate == nil)
+        #expect(!state.isActive())
+        #expect(state.count == 1)
+        #expect(state.blockingProcessDeferralCount == 1)
+    }
+
+    @Test func resetClearsSplitCounters() {
+        var state = DeferralState()
+        state.recordDeferral(minutes: 30, kind: .user)
+        state.recordDeferral(minutes: 30, kind: .timedOut)
+        state.recordBlockingProcessSkip()
+        state.reset()
+        #expect(state.userDeferralCount == 0)
+        #expect(state.timedOutDeferralCount == 0)
+        #expect(state.blockingProcessDeferralCount == 0)
+    }
+
+    @Test func decodesLegacyStateWithoutSplitCounters() throws {
+        let json = #"{"count":2}"#.data(using: .utf8)!
+        let state = try JSONDecoder().decode(DeferralState.self, from: json)
+        #expect(state.count == 2)
+        #expect(state.userDeferralCount == 0)
+        #expect(state.timedOutDeferralCount == 0)
+        #expect(state.blockingProcessDeferralCount == 0)
+    }
+
+    @Test func splitCountersRoundTripThroughJSON() throws {
+        var state = DeferralState()
+        state.recordDeferral(minutes: 60, kind: .user)
+        state.recordDeferral(minutes: 60, kind: .timedOut)
+        state.recordBlockingProcessSkip()
+        let encoder = JSONEncoder(); encoder.dateEncodingStrategy = .iso8601
+        let decoder = JSONDecoder(); decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(DeferralState.self, from: try encoder.encode(state))
+        #expect(decoded.count == 3)
+        #expect(decoded.userDeferralCount == 1)
+        #expect(decoded.timedOutDeferralCount == 1)
+        #expect(decoded.blockingProcessDeferralCount == 1)
+    }
 }
 
 


### PR DESCRIPTION
This splits the deferral counts to separate attributes to track user deferrals, automatic timeout deferrals, and automatic blocking deferrals, for more insights and reporting.