### PR TITLE
patcherreport: add deadline math and 'get' subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ The `patcherreport` binary generates compliance reports from local state files w
 | `never-updated` | Apps with no successful apply on record |
 | `label` | Full chronological event history for one app |
 | `deferrals` | Audit log of every dialog interaction and user choice |
+| `get` | One scalar value from a report's JSON payload (for Jamf Extension Attributes) |
+
+`summary` and `pending` also report a deadline block (patching mode, oldest pending age, Focus/hard deadline dates, days remaining).
 
 See the **[Reporting wiki page](../../wiki/Reporting)** for usage and output format.
 

--- a/patcherreport/BrokenReporter.swift
+++ b/patcherreport/BrokenReporter.swift
@@ -59,6 +59,14 @@ struct BrokenReporter {
     }
 
     private func buildJSON(_ ctx: ReportContext) -> String {
+        guard let data = try? JSONSerialization.data(
+                withJSONObject: jsonObject(ctx),
+                options: [.prettyPrinted, .sortedKeys]) else { return "{}" }
+        return String(data: data, encoding: .utf8) ?? "{}"
+    }
+
+    /// The `broken --json` payload. Also consumed by the `get` subcommand.
+    func jsonObject(_ ctx: ReportContext) -> [String: Any] {
         let iso            = ISO8601DateFormatter()
         let scanBroken     = (ctx.config["lastScanBrokenLabels"] as? [String] ?? []).sorted()
         let stageBroken    = (ctx.config["stageBrokenLabels"]    as? [String] ?? []).sorted()
@@ -71,13 +79,11 @@ struct BrokenReporter {
             if let a = failedAttempts[label] { d["failedAttempts"] = a }
             return d
         }
-        let out: [String: Any] = [
+        return [
             "generatedAt": iso.string(from: ctx.now),
             "scanBroken":  ["installomatorVersion": scanVersion, "labels": scanBroken],
             "stageBroken": ["installomatorVersion": stageVersion, "labels": stageArr]
         ]
-        guard let data = try? JSONSerialization.data(withJSONObject: out, options: [.prettyPrinted, .sortedKeys]) else { return "{}" }
-        return String(data: data, encoding: .utf8) ?? "{}"
     }
 
     private func buildCSV(_ ctx: ReportContext) -> String {

--- a/patcherreport/DeadlineSummary.swift
+++ b/patcherreport/DeadlineSummary.swift
@@ -1,0 +1,167 @@
+//
+//  DeadlineSummary.swift
+//  patcherreport
+//
+//  Deadline math for the summary and pending reports.  Mirrors the calculations
+//  the daemon performs in `PatchSchedule` so admins (and Jamf Extension
+//  Attributes) can see how close a device is to its Focus / hard deadline.
+//
+
+import Foundation
+
+struct DeadlineSummary {
+
+    /// "monthly" when MonthlyPatchingCadenceEnabled, otherwise "deadline".
+    let patchingMode: String
+
+    /// Number of staged-but-not-applied updates.
+    let pendingCount: Int
+
+    /// Earliest `stagedTimestamp` among the pending updates.
+    let oldestPendingDate: Date?
+    /// Whole calendar days since `oldestPendingDate` (0 when nothing is pending).
+    let oldestPendingDays: Int
+
+    /// The date deadlines are measured from: the scheduler's firstPendingDate in
+    /// deadline mode, or this month's patch day (once passed) in monthly mode.
+    /// nil when nothing is pending, or in monthly mode before patch day.
+    let deadlineReferenceDate: Date?
+    /// Whole days elapsed since `deadlineReferenceDate` (0 when there is none).
+    let daysPendingForDeadline: Int
+
+    /// Configured thresholds (0 = disabled).
+    let deadlineDaysFocus: Int
+    let deadlineDaysHard: Int
+
+    /// Absolute dates the thresholds are reached. nil when the threshold is
+    /// disabled or there is no active deadline reference.
+    let focusDeadlineDate: Date?
+    let hardDeadlineDate: Date?
+
+    /// Whole days from now until each deadline (negative once passed).
+    /// nil when the corresponding date is nil.
+    let daysUntilFocusDeadline: Int?
+    let daysUntilHardDeadline: Int?
+
+    /// Whether each threshold has already been reached.
+    let focusDeadlineReached: Bool
+    let hardDeadlineReached: Bool
+
+    // MARK: - Build
+
+    init(_ ctx: ReportContext, pendingItems: [PendingItem]) {
+        let now      = ctx.now
+        let prefs    = ctx.prefs
+        let schedule = PatchSchedule(prefs: prefs)
+        let cal      = Calendar.current
+
+        patchingMode = prefs.monthlyPatchingCadenceEnabled ? "monthly" : "deadline"
+        pendingCount = pendingItems.count
+
+        let oldest = pendingItems.map(\.stagedDate).min()
+        oldestPendingDate = oldest
+        oldestPendingDays = oldest.map { cal.dateComponents([.day], from: $0, to: now).day ?? 0 } ?? 0
+
+        // The scheduler's firstPendingDate is authoritative; fall back to the
+        // oldest staged timestamp (the same fallback the patcher itself uses).
+        let firstPending = ctx.schedulerState.firstPendingDate ?? oldest
+
+        deadlineReferenceDate  = schedule.deadlineReference(firstPendingDate: firstPending, now: now)
+        daysPendingForDeadline = schedule.daysPendingForDeadline(firstPendingDate: firstPending, now: now)
+
+        deadlineDaysFocus = prefs.deadlineDaysFocus
+        deadlineDaysHard  = prefs.deadlineDaysHard
+
+        let focusDate = schedule.focusDeadlineDate(firstPendingDate: firstPending, now: now)
+        let hardDate  = schedule.hardDeadlineDate(firstPendingDate: firstPending, now: now)
+        focusDeadlineDate = focusDate
+        hardDeadlineDate  = hardDate
+
+        daysUntilFocusDeadline = focusDate.map { cal.dateComponents([.day], from: now, to: $0).day ?? 0 }
+        daysUntilHardDeadline  = hardDate.map  { cal.dateComponents([.day], from: now, to: $0).day ?? 0 }
+
+        focusDeadlineReached = schedule.isFocusDeadlineReached(firstPendingDate: firstPending, now: now)
+        hardDeadlineReached  = schedule.isHardDeadlineReached(firstPendingDate: firstPending, now: now)
+    }
+
+    // MARK: - Serialisation
+
+    /// Nested dictionary used by the `summary` / `pending` JSON payloads and by `get`.
+    func jsonObject() -> [String: Any] {
+        let iso = ISO8601DateFormatter()
+        var d: [String: Any] = [
+            "patchingMode":           patchingMode,
+            "pendingCount":           pendingCount,
+            "oldestPendingDays":      oldestPendingDays,
+            "daysPendingForDeadline": daysPendingForDeadline,
+            "deadlineDaysFocus":      deadlineDaysFocus,
+            "deadlineDaysHard":       deadlineDaysHard,
+            "focusDeadlineReached":   focusDeadlineReached,
+            "hardDeadlineReached":    hardDeadlineReached,
+        ]
+        if let v = oldestPendingDate      { d["oldestPendingDate"]      = iso.string(from: v) }
+        if let v = deadlineReferenceDate  { d["deadlineReferenceDate"]  = iso.string(from: v) }
+        if let v = focusDeadlineDate      { d["focusDeadlineDate"]      = iso.string(from: v) }
+        if let v = hardDeadlineDate       { d["hardDeadlineDate"]       = iso.string(from: v) }
+        if let v = daysUntilFocusDeadline { d["daysUntilFocusDeadline"] = v }
+        if let v = daysUntilHardDeadline  { d["daysUntilHardDeadline"]  = v }
+        return d
+    }
+
+    /// Rows for the `summary` / `pending` CSV payloads (metric,value form).
+    func csvRows() -> [[String]] {
+        let iso = ISO8601DateFormatter()
+        let rows: [[String]] = [
+            ["patchingMode",           patchingMode],
+            ["pendingCount",           "\(pendingCount)"],
+            ["oldestPendingDate",      oldestPendingDate.map { iso.string(from: $0) } ?? ""],
+            ["oldestPendingDays",      "\(oldestPendingDays)"],
+            ["deadlineReferenceDate",  deadlineReferenceDate.map { iso.string(from: $0) } ?? ""],
+            ["daysPendingForDeadline", "\(daysPendingForDeadline)"],
+            ["deadlineDaysFocus",      "\(deadlineDaysFocus)"],
+            ["deadlineDaysHard",       "\(deadlineDaysHard)"],
+            ["focusDeadlineDate",      focusDeadlineDate.map { iso.string(from: $0) } ?? ""],
+            ["hardDeadlineDate",       hardDeadlineDate.map { iso.string(from: $0) } ?? ""],
+            ["daysUntilFocusDeadline", daysUntilFocusDeadline.map { "\($0)" } ?? ""],
+            ["daysUntilHardDeadline",  daysUntilHardDeadline.map { "\($0)" } ?? ""],
+            ["focusDeadlineReached",   "\(focusDeadlineReached)"],
+            ["hardDeadlineReached",    "\(hardDeadlineReached)"],
+        ]
+        return rows
+    }
+
+    /// Lines for the human-readable table reports.
+    func tableLines() -> [String] {
+        var lines: [String] = []
+        func line(_ label: String, _ value: String) -> String { " \(col(label, 34)) \(value)" }
+
+        lines.append(line("Patching mode:", patchingMode))
+        if pendingCount == 0 {
+            lines.append(line("Pending updates:", "none — no active deadline"))
+            return lines
+        }
+
+        if let oldest = oldestPendingDate {
+            lines.append(line("Oldest pending update:", "\(shortDate(oldest))  (\(oldestPendingDays)d ago)"))
+        }
+        if let ref = deadlineReferenceDate {
+            lines.append(line("Deadline measured from:", "\(shortDate(ref))  (\(daysPendingForDeadline)d elapsed)"))
+        } else if patchingMode == "monthly" {
+            lines.append(line("Deadline measured from:", "patch day not yet reached"))
+        }
+
+        func deadlineLine(_ label: String, days: Int, date: Date?, until: Int?, reached: Bool) -> String {
+            guard days > 0 else { return line(label, "disabled") }
+            guard let date, let until else { return line(label, "\(days)d threshold — not yet started") }
+            if reached { return line(label, "REACHED — \(shortDate(date))") }
+            return line(label, "\(shortDate(date))  (in \(until)d)")
+        }
+        lines.append(deadlineLine("Focus deadline:", days: deadlineDaysFocus,
+                                  date: focusDeadlineDate, until: daysUntilFocusDeadline,
+                                  reached: focusDeadlineReached))
+        lines.append(deadlineLine("Hard deadline:", days: deadlineDaysHard,
+                                  date: hardDeadlineDate, until: daysUntilHardDeadline,
+                                  reached: hardDeadlineReached))
+        return lines
+    }
+}

--- a/patcherreport/DeferralsReporter.swift
+++ b/patcherreport/DeferralsReporter.swift
@@ -218,6 +218,14 @@ struct DeferralsReporter {
     // MARK: JSON
 
     private func buildJSON(_ ctx: ReportContext) -> String {
+        guard let data = try? JSONSerialization.data(
+                withJSONObject: jsonObject(ctx),
+                options: [.prettyPrinted, .sortedKeys]) else { return "{}" }
+        return String(data: data, encoding: .utf8) ?? "{}"
+    }
+
+    /// The `deferrals --json` payload. Also consumed by the `get` subcommand.
+    func jsonObject(_ ctx: ReportContext) -> [String: Any] {
         let iso = ISO8601DateFormatter()
         let labelsWithEvents = labelDialogEvents(ctx)
 
@@ -261,8 +269,7 @@ struct DeferralsReporter {
             ],
             "labels": arr,
         ]
-        guard let data = try? JSONSerialization.data(withJSONObject: out, options: [.prettyPrinted, .sortedKeys]) else { return "{}" }
-        return String(data: data, encoding: .utf8) ?? "{}"
+        return out
     }
 
     // MARK: CSV

--- a/patcherreport/GetReporter.swift
+++ b/patcherreport/GetReporter.swift
@@ -1,0 +1,99 @@
+//
+//  GetReporter.swift
+//  patcherreport
+//
+//  patcherreport get <key> [--from summary|pending|deferrals|broken|deadline] [--days N]
+//
+//  Prints a single scalar value from one of the JSON report payloads, with no
+//  quoting or wrapping. Intended for Jamf Extension Attributes and other scripts
+//  that would otherwise have to parse `--json` output with a tool that isn't on a
+//  stock macOS install.
+//
+//  The <key> is a dotted path into the JSON object, e.g.
+//    patcherreport get updateRequired
+//    patcherreport get deadline.daysUntilHardDeadline
+//    patcherreport get lastApply.lastRun
+//    patcherreport get totals.deferrals --from deferrals --days 30
+//
+//  A key that resolves to an array of scalars is printed one item per line.
+//  Exit status is 1 (with a message on stderr) when the key is missing or
+//  resolves to an object.
+//
+
+import Foundation
+
+struct GetReporter {
+    let key:    String
+    let source: String
+    let days:   Int?
+
+    static let validSources = ["summary", "pending", "deferrals", "broken", "deadline"]
+
+    func run(to path: String?) {
+        let ctx = ReportContext()
+
+        let object: [String: Any]
+        switch source {
+        case "summary":
+            object = SummaryReporter(format: .json).jsonObject(ctx)
+        case "pending":
+            object = PendingReporter(format: .json).jsonObject(ctx)
+        case "deferrals":
+            object = DeferralsReporter(days: days, format: .json).jsonObject(ctx)
+        case "broken":
+            object = BrokenReporter(format: .json).jsonObject(ctx)
+        case "deadline":
+            object = DeadlineSummary(ctx, pendingItems: buildPendingItems(ctx)).jsonObject()
+        default:
+            fputs("patcherreport: unknown --from source '\(source)' (expected \(Self.validSources.joined(separator: ", ")))\n", stderr)
+            exit(1)
+        }
+
+        guard let value = lookup(key, in: object) else {
+            fputs("patcherreport: key '\(key)' not found in '\(source)'\n", stderr)
+            exit(1)
+        }
+
+        guard let rendered = render(value) else {
+            fputs("patcherreport: key '\(key)' refers to an object, not a scalar — specify a sub-key\n", stderr)
+            exit(1)
+        }
+
+        emit(rendered, to: path)
+    }
+
+    // MARK: - Path lookup
+
+    /// Walks a dotted key path through nested dictionaries.
+    private func lookup(_ path: String, in object: [String: Any]) -> Any? {
+        var current: Any = object
+        for component in path.split(separator: ".").map(String.init) {
+            guard let dict = current as? [String: Any], let next = dict[component] else { return nil }
+            current = next
+        }
+        return current
+    }
+
+    // MARK: - Rendering
+
+    /// Renders a scalar (or array of scalars) to plain text. Returns nil for objects.
+    private func render(_ value: Any) -> String? {
+        switch value {
+        case let s as String:
+            return s
+        case let b as Bool:
+            return b ? "true" : "false"
+        case let n as Int:
+            return "\(n)"
+        case let n as Double:
+            return "\(n)"
+        case let n as NSNumber:
+            return n.stringValue
+        case let array as [Any]:
+            let parts = array.compactMap { render($0) }
+            return parts.count == array.count ? parts.joined(separator: "\n") : nil
+        default:
+            return nil
+        }
+    }
+}

--- a/patcherreport/PendingReporter.swift
+++ b/patcherreport/PendingReporter.swift
@@ -17,9 +17,15 @@ struct PendingReporter {
         let items = buildPendingItems(ctx)
         switch format {
         case .table: emit(buildTable(items, ctx: ctx), to: path)
-        case .json:  emit(buildJSON(items,  ctx: ctx), to: path)
-        case .csv:   emit(buildCSV(items),             to: path)
+        case .json:  emit(prettyJSON(jsonObject(ctx)), to: path)
+        case .csv:   emit(buildCSV(items, ctx: ctx),   to: path)
         }
+    }
+
+    private func prettyJSON(_ obj: [String: Any]) -> String {
+        guard let data = try? JSONSerialization.data(
+                withJSONObject: obj, options: [.prettyPrinted, .sortedKeys]) else { return "{}" }
+        return String(data: data, encoding: .utf8) ?? "{}"
     }
 
     private func buildTable(_ items: [PendingItem], ctx: ReportContext) -> String {
@@ -37,13 +43,17 @@ struct PendingReporter {
                 let v = item.stagedVersion.isEmpty ? "(unknown)" : "v\(item.stagedVersion)"
                 lines.append(" \(col(item.label, 26))  \(col(v, 12))  \(col(shortDateTime(item.stagedDate), 16))  \(item.daysPending)d")
             }
+            lines.append(String(repeating: "─", count: w))
+            lines.append(contentsOf: DeadlineSummary(ctx, pendingItems: items).tableLines())
         }
         lines.append(String(repeating: "═", count: w))
         return lines.joined(separator: "\n")
     }
 
-    private func buildJSON(_ items: [PendingItem], ctx: ReportContext) -> String {
-        let iso = ISO8601DateFormatter()
+    /// The `pending --json` payload. Also consumed by the `get` subcommand.
+    func jsonObject(_ ctx: ReportContext) -> [String: Any] {
+        let iso   = ISO8601DateFormatter()
+        let items = buildPendingItems(ctx)
         let arr: [[String: Any]] = items.map { item in
             var d: [String: Any] = [
                 "label":       item.label,
@@ -54,12 +64,14 @@ struct PendingReporter {
             if !item.installedVersion.isEmpty { d["installedVersion"] = item.installedVersion }
             return d
         }
-        let out: [String: Any] = ["generatedAt": iso.string(from: ctx.now), "pending": arr]
-        guard let data = try? JSONSerialization.data(withJSONObject: out, options: [.prettyPrinted, .sortedKeys]) else { return "{}" }
-        return String(data: data, encoding: .utf8) ?? "{}"
+        return [
+            "generatedAt": iso.string(from: ctx.now),
+            "pending":     arr,
+            "deadline":    DeadlineSummary(ctx, pendingItems: items).jsonObject(),
+        ]
     }
 
-    private func buildCSV(_ items: [PendingItem]) -> String {
+    private func buildCSV(_ items: [PendingItem], ctx: ReportContext) -> String {
         var rows = [csvRow(["label", "stagedVersion", "stagedDate", "installedVersion", "daysPending"])]
         for item in items {
             rows.append(csvRow([

--- a/patcherreport/ReportContext.swift
+++ b/patcherreport/ReportContext.swift
@@ -17,9 +17,15 @@ struct ReportContext {
     let discoveredPlists: [String: [String: Any]]
     /// Contents of config.json.
     let config:           [String: Any]
+    /// Managed / local preferences (deadline thresholds, patching cadence, …).
+    let prefs:            Preferences
+    /// Snapshot of the scheduler's persistent state (firstPendingDate, lastApplyDate).
+    let schedulerState:   SchedulerStateSnapshot
 
     init() {
         now = Date()
+        prefs = Preferences()
+        schedulerState = SchedulerStateSnapshot.load()
         let fm = FileManager.default
 
         // History files: Cache/<label>/history.json

--- a/patcherreport/SchedulerStateSnapshot.swift
+++ b/patcherreport/SchedulerStateSnapshot.swift
@@ -1,0 +1,39 @@
+//
+//  SchedulerStateSnapshot.swift
+//  patcherreport
+//
+//  Read-only view of the daemon's scheduler_state.json.  The authoritative
+//  `SchedulerState` type lives in the patcherscheduler target; patcherreport only
+//  needs a couple of fields for deadline math, so it decodes them directly rather
+//  than pulling in the whole type.
+//
+
+import Foundation
+
+struct SchedulerStateSnapshot {
+    /// When staged updates first appeared and started the deadline clock.
+    /// Cleared by the scheduler once every staged update has been applied.
+    let firstPendingDate: Date?
+    /// Timestamp of the last apply run recorded by the scheduler.
+    let lastApplyDate: Date?
+
+    static let empty = SchedulerStateSnapshot(firstPendingDate: nil, lastApplyDate: nil)
+
+    static func load() -> SchedulerStateSnapshot {
+        let url = AppConstants.patcherConfigFolderURL
+            .appendingPathComponent("scheduler_state.json")
+        guard let data = try? Data(contentsOf: url),
+              let obj  = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return .empty }
+
+        // SchedulerState.save() encodes dates with JSONEncoder's .iso8601 strategy.
+        let iso = ISO8601DateFormatter()
+        func date(_ key: String) -> Date? {
+            (obj[key] as? String).flatMap { iso.date(from: $0) }
+        }
+        return SchedulerStateSnapshot(
+            firstPendingDate: date("firstPendingDate"),
+            lastApplyDate:    date("lastApplyDate")
+        )
+    }
+}

--- a/patcherreport/SummaryReporter.swift
+++ b/patcherreport/SummaryReporter.swift
@@ -79,12 +79,23 @@ struct SummaryReporter {
         lines.append(runLine("Last check:", startKey: "lastCheckStart",    countKey: "lastCheckLabelCount",    countNoun: "checked"))
         lines.append(runLine("Last stage:", startKey: "lastStageStart",    countKey: "lastStagedCount",        countNoun: "staged"))
         lines.append(runLine("Last apply:", startKey: "lastApplyStart",    countKey: "lastApplyCount",         countNoun: "applied"))
+        lines.append(String(repeating: "─", count: w))
+
+        lines.append(contentsOf: DeadlineSummary(ctx, pendingItems: buildPendingItems(ctx)).tableLines())
         lines.append(String(repeating: "═", count: w))
 
         return lines.joined(separator: "\n")
     }
 
     private func buildJSON(_ ctx: ReportContext) -> String {
+        guard let data = try? JSONSerialization.data(
+                withJSONObject: jsonObject(ctx),
+                options: [.prettyPrinted, .sortedKeys]) else { return "{}" }
+        return String(data: data, encoding: .utf8) ?? "{}"
+    }
+
+    /// The `summary --json` payload. Also consumed by the `get` subcommand.
+    func jsonObject(_ ctx: ReportContext) -> [String: Any] {
         let iso = ISO8601DateFormatter()
         let sc = statusCounts(ctx)
         let everApplied = ctx.histories.filter {
@@ -116,8 +127,9 @@ struct SummaryReporter {
         addRun("lastStage",  startKey: "lastStageStart",    countKey: "lastStagedCount")
         addRun("lastApply",  startKey: "lastApplyStart",    countKey: "lastApplyCount")
 
-        guard let data = try? JSONSerialization.data(withJSONObject: d, options: [.prettyPrinted, .sortedKeys]) else { return "{}" }
-        return String(data: data, encoding: .utf8) ?? "{}"
+        d["deadline"] = DeadlineSummary(ctx, pendingItems: buildPendingItems(ctx)).jsonObject()
+
+        return d
     }
 
     private func buildCSV(_ ctx: ReportContext) -> String {
@@ -125,7 +137,7 @@ struct SummaryReporter {
         let everApplied = ctx.histories.filter {
             $0.history.events.contains { $0.type == LabelHistoryEvent.EventType.applied }
         }.count
-        let rows: [[String]] = [
+        var rows: [[String]] = [
             ["metric", "value"],
             ["totalDiscovered",    "\(ctx.discoveredPlists.count)"],
             ["upToDate",           "\(sc["upToDate"]      ?? 0)"],
@@ -138,6 +150,7 @@ struct SummaryReporter {
             ["scanBrokenCount",    "\((ctx.config["lastScanBrokenLabels"] as? [String] ?? []).count)"],
             ["stageBrokenCount",   "\((ctx.config["stageBrokenLabels"]    as? [String] ?? []).count)"],
         ]
+        rows.append(contentsOf: DeadlineSummary(ctx, pendingItems: buildPendingItems(ctx)).csvRows())
         return rows.map(csvRow).joined(separator: "\n")
     }
 }

--- a/patcherreport/main.swift
+++ b/patcherreport/main.swift
@@ -12,6 +12,7 @@
 //    patcherreport never-updated             Labels discovered but never applied
 //    patcherreport broken                    Broken scan and stage labels
 //    patcherreport deferrals [--days N]      Dialog interaction history (deferrals, blocking-process)
+//    patcherreport get <key> [--from src]    Print one scalar value from a report's JSON payload
 //
 //  Output options (apply to any subcommand):
 //    --json                                  Output as JSON
@@ -64,6 +65,14 @@ case "deferrals":
     let days = flagInt(cliArgs, flag: "--days")
     DeferralsReporter(days: days, format: outputFormat).run(to: outputPath)
 
+case "get":
+    guard let key = cliArgs.dropFirst().first(where: { !$0.hasPrefix("-") }) else {
+        fputs("patcherreport: 'get' requires a key, e.g. 'patcherreport get updateRequired'\n", stderr); exit(1)
+    }
+    let source = flagString(cliArgs, flag: "--from") ?? "summary"
+    let days   = flagInt(cliArgs, flag: "--days")
+    GetReporter(key: key, source: source, days: days).run(to: outputPath)
+
 case "help":
     printUsage(); exit(0)
 
@@ -87,6 +96,18 @@ func printUsage() {
       never-updated             Labels discovered but never applied
       broken                    Broken scan and stage labels
       deferrals [--days N]      Dialog interaction history: deferrals, blocking-process outcomes
+      get <key> [--from src]    Print one scalar value from a report's JSON payload
+
+    'get' options:
+      --from <src>              summary (default), pending, deferrals, broken, deadline
+      --days N                  History window when --from is 'deferrals'
+
+      Examples:
+        patcherreport get updateRequired
+        patcherreport get labelsPending
+        patcherreport get deadline.daysUntilHardDeadline
+        patcherreport get lastApply.lastRun
+        patcherreport get totals.deferrals --from deferrals --days 30
 
     Options:
       --json                    Output as JSON
@@ -147,6 +168,11 @@ func col(_ s: String, _ width: Int) -> String {
 private func flagInt(_ args: [String], flag: String) -> Int? {
     guard let idx = args.firstIndex(of: flag), idx + 1 < args.count else { return nil }
     return Int(args[idx + 1])
+}
+
+private func flagString(_ args: [String], flag: String) -> String? {
+    guard let idx = args.firstIndex(of: flag), idx + 1 < args.count else { return nil }
+    return args[idx + 1]
 }
 
 /// Wraps a CSV field in quotes if it contains commas, quotes, or newlines.


### PR DESCRIPTION
Adds Focus / hard-deadline calculations to the `summary` and `pending` reports, mirroring the enforcement the scheduler performs in PatchSchedule. Measured from the scheduler's firstPendingDate (deadline mode) or this month's patch day once passed (monthly mode), falling back to the oldest staged update's timestamp.

  - summary/pending --json gain a nested `deadline` object
  - summary --csv gains matching metric rows
  - table output gains a deadline section

New `patcherreport get <key> [--from summary|pending|deferrals|broken|deadline]` prints a single scalar from a report's JSON payload with no quoting or wrapping, so Jamf Extension Attributes and other scripts don't need a JSON parser that isn't on a stock macOS install. Arrays of scalars print one per line; missing keys or objects exit non-zero.

ReportContext now also loads Preferences and a read-only snapshot of scheduler_state.json (SchedulerStateSnapshot).
