### PR TITLE
Add Jamf Pro Extension Attribute scripts for patcherreport

### DIFF
--- a/MDM Examples/Jamf Extension Attributes/README.md
+++ b/MDM Examples/Jamf Extension Attributes/README.md
@@ -1,0 +1,74 @@
+# Jamf Pro Extension Attributes
+
+Ready-to-use Extension Attribute (EA) scripts that pull Third Party Patcher status
+into Jamf Pro inventory. Each script shells out to `patcherreport` — mostly its
+`get` subcommand — and echoes a single `<result>` value.
+
+No `jq`, `python3`, or other add-ons are required; the scripts use only tools
+present on a stock macOS install.
+
+## Included scripts
+
+| Script | EA display name | Data type | What it reports |
+|--------|-----------------|-----------|----------------|
+| `tpp-last-scan.sh` | TPP - Last Scan | Date | Last full Installomator scan (UTC) |
+| `tpp-last-apply.sh` | TPP - Last Apply | Date | Last apply/install pass (UTC) |
+| `tpp-apps-requiring-update.sh` | TPP - Apps Requiring Update | Integer | Managed apps found out of date |
+| `tpp-pending-updates.sh` | TPP - Pending Updates | Integer | Updates staged and awaiting apply |
+| `tpp-oldest-pending-days.sh` | TPP - Oldest Pending Update (Days) | Integer | Age of the oldest staged update |
+| `tpp-days-until-hard-deadline.sh` | TPP - Days Until Hard Deadline | Integer | Days left before deferrals are cut off |
+| `tpp-broken-labels.sh` | TPP - Broken Labels | Integer | Scan-broken + stage-broken labels |
+| `tpp-deferrals-30-days.sh` | TPP - Deferrals (Last 30 Days) | Integer | Dialog deferrals in the last 30 days |
+| `tpp-deadlines-forced.sh` | TPP - Deadlines Forced (Lifetime) | Integer | Times a hard deadline forced an install |
+| `tpp-patching-mode.sh` | TPP - Patching Mode | String | `monthly` or `deadline` |
+| `tpp-pending-update-labels.sh` | TPP - Pending Update Labels | String | Comma-separated list of staged labels |
+| `tpp-patch-compliance-status.sh` | TPP - Patch Compliance Status | String | Rollup verdict (see below) |
+
+### Compliance status values
+
+`tpp-patch-compliance-status.sh` returns one of:
+
+| Value | Meaning |
+|-------|---------|
+| `Not Installed` | `patcherreport` is not present on the device |
+| `Overdue` | A hard deadline has been reached |
+| `Deadline Approaching` | Updates pending, hard deadline within 3 days |
+| `Pending` | Updates staged, deadline not yet close |
+| `Updates Detected` | Updates found but nothing staged yet |
+| `Compliant` | Nothing outstanding |
+
+## Adding an EA to Jamf Pro
+
+1. **Settings ▸ Computer Management ▸ Extension Attributes ▸ New**
+2. **Display Name:** use the name from the table above (the `TPP -` prefix keeps
+   them grouped).
+3. **Data Type:** match the table.
+4. **Input Type:** Script — paste the script contents.
+5. Save. Values populate on each device's next inventory submission (`jamf recon`).
+
+## Notes
+
+- **Binary path.** Scripts call `/usr/local/bin/tpp/patcherreport`. If you deploy
+  the dev build (`/usr/local/bin/tpp_dev/`), adjust the `patcherreport=` line.
+- **No root required.** `patcherreport` only reads state files, but EA scripts run
+  as root under Jamf anyway.
+- **Dates are UTC.** Jamf stores EA dates as `YYYY-MM-DD hh:mm:ss` in UTC; the
+  date scripts convert `patcherreport`'s ISO-8601 output accordingly.
+- **Freshness.** These values are only as current as the last inventory. Pair a
+  scan/apply-heavy smart group with a shorter recon interval if you need tighter
+  reporting.
+
+## Building your own
+
+`patcherreport get <dotted.key> [--from summary|pending|deferrals|broken|deadline]`
+prints any single scalar from the JSON payloads with no quoting or wrapping:
+
+```bash
+patcherreport get labelsNeverUpdated
+patcherreport get lastCheck.lastRun
+patcherreport get deadline.hardDeadlineReached
+patcherreport get totals.user --from deferrals --days 14
+```
+
+See the [Reporting wiki page](https://github.com/gilburns/Third-Party-Patcher/wiki/Reporting)
+for the full list of keys.

--- a/MDM Examples/Jamf Extension Attributes/tpp-apps-requiring-update.sh
+++ b/MDM Examples/Jamf Extension Attributes/tpp-apps-requiring-update.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# Jamf Pro Extension Attribute — Third Party Patcher
+#   Display name : TPP - Apps Requiring Update
+#   Data type    : Integer
+#   Input type   : Script
+#
+# Number of managed apps the last check found to be out of date (whether or
+# not the update has been staged yet).
+#
+
+patcherreport="/usr/local/bin/tpp/patcherreport"
+[[ -x "$patcherreport" ]] || { echo "<result></result>"; exit 0; }
+
+value=$("$patcherreport" get updateRequired 2>/dev/null)
+
+echo "<result>${value:-0}</result>"

--- a/MDM Examples/Jamf Extension Attributes/tpp-broken-labels.sh
+++ b/MDM Examples/Jamf Extension Attributes/tpp-broken-labels.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# Jamf Pro Extension Attribute — Third Party Patcher
+#   Display name : TPP - Broken Labels
+#   Data type    : Integer
+#   Input type   : Script
+#
+# Combined count of scan-broken and stage-broken labels — labels that could
+# not be evaluated or repeatedly failed to download. See `patcherreport broken`
+# for the list.
+#
+
+patcherreport="/usr/local/bin/tpp/patcherreport"
+[[ -x "$patcherreport" ]] || { echo "<result></result>"; exit 0; }
+
+scan=$("$patcherreport" get scanBrokenCount 2>/dev/null)
+stage=$("$patcherreport" get stageBrokenCount 2>/dev/null)
+
+echo "<result>$(( ${scan:-0} + ${stage:-0} ))</result>"

--- a/MDM Examples/Jamf Extension Attributes/tpp-days-until-hard-deadline.sh
+++ b/MDM Examples/Jamf Extension Attributes/tpp-days-until-hard-deadline.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Jamf Pro Extension Attribute — Third Party Patcher
+#   Display name : TPP - Days Until Hard Deadline
+#   Data type    : Integer
+#   Input type   : Script
+#
+# Whole days from now until the hard deadline, after which no further
+# deferrals are allowed and the update is forced. Negative once the deadline
+# has passed. Blank when nothing is pending or DeadlineDaysHard is 0.
+#
+
+patcherreport="/usr/local/bin/tpp/patcherreport"
+[[ -x "$patcherreport" ]] || { echo "<result></result>"; exit 0; }
+
+value=$("$patcherreport" get deadline.daysUntilHardDeadline 2>/dev/null)
+
+echo "<result>${value}</result>"

--- a/MDM Examples/Jamf Extension Attributes/tpp-deadlines-forced.sh
+++ b/MDM Examples/Jamf Extension Attributes/tpp-deadlines-forced.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# Jamf Pro Extension Attribute — Third Party Patcher
+#   Display name : TPP - Deadlines Forced (Lifetime)
+#   Data type    : Integer
+#   Input type   : Script
+#
+# Number of times a hard deadline was reached and an update proceeded without
+# the user getting to choose. Counted across all recorded history.
+#
+
+patcherreport="/usr/local/bin/tpp/patcherreport"
+[[ -x "$patcherreport" ]] || { echo "<result></result>"; exit 0; }
+
+value=$("$patcherreport" get totals.deadlinesForced --from deferrals 2>/dev/null)
+
+echo "<result>${value:-0}</result>"

--- a/MDM Examples/Jamf Extension Attributes/tpp-deferrals-30-days.sh
+++ b/MDM Examples/Jamf Extension Attributes/tpp-deferrals-30-days.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Jamf Pro Extension Attribute — Third Party Patcher
+#   Display name : TPP - Deferrals (Last 30 Days)
+#   Data type    : Integer
+#   Input type   : Script
+#
+# Total dialog deferrals recorded in the last 30 days (user-chosen +
+# timer-timeout + blocking-process skips). A persistently high value flags a
+# device whose user keeps putting patching off.
+#
+
+patcherreport="/usr/local/bin/tpp/patcherreport"
+[[ -x "$patcherreport" ]] || { echo "<result></result>"; exit 0; }
+
+value=$("$patcherreport" get totals.deferrals --from deferrals --days 30 2>/dev/null)
+
+echo "<result>${value:-0}</result>"

--- a/MDM Examples/Jamf Extension Attributes/tpp-last-apply.sh
+++ b/MDM Examples/Jamf Extension Attributes/tpp-last-apply.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Jamf Pro Extension Attribute — Third Party Patcher
+#   Display name : TPP - Last Apply
+#   Data type    : Date
+#   Input type   : Script
+#
+# When the daemon last ran an apply (install) pass (UTC). Blank if it has
+# never applied an update on this device.
+#
+
+patcherreport="/usr/local/bin/tpp/patcherreport"
+[[ -x "$patcherreport" ]] || { echo "<result></result>"; exit 0; }
+
+iso=$("$patcherreport" get lastApply.lastRun 2>/dev/null)
+
+value=""
+if [[ -n "$iso" ]]; then
+    value=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$iso" "+%Y-%m-%d %H:%M:%S" 2>/dev/null)
+fi
+
+echo "<result>${value}</result>"

--- a/MDM Examples/Jamf Extension Attributes/tpp-last-scan.sh
+++ b/MDM Examples/Jamf Extension Attributes/tpp-last-scan.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# Jamf Pro Extension Attribute — Third Party Patcher
+#   Display name : TPP - Last Scan
+#   Data type    : Date
+#   Input type   : Script
+#
+# When the daemon last ran a full Installomator scan (UTC).
+#
+
+patcherreport="/usr/local/bin/tpp/patcherreport"
+[[ -x "$patcherreport" ]] || { echo "<result></result>"; exit 0; }
+
+iso=$("$patcherreport" get lastScan.lastRun 2>/dev/null)
+
+value=""
+if [[ -n "$iso" ]]; then
+    value=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$iso" "+%Y-%m-%d %H:%M:%S" 2>/dev/null)
+fi
+
+echo "<result>${value}</result>"

--- a/MDM Examples/Jamf Extension Attributes/tpp-oldest-pending-days.sh
+++ b/MDM Examples/Jamf Extension Attributes/tpp-oldest-pending-days.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Jamf Pro Extension Attribute — Third Party Patcher
+#   Display name : TPP - Oldest Pending Update (Days)
+#   Data type    : Integer
+#   Input type   : Script
+#
+# Age in days of the oldest staged-but-not-applied update. 0 when nothing is
+# pending. Useful for smart groups that escalate as devices approach the
+# deadline.
+#
+
+patcherreport="/usr/local/bin/tpp/patcherreport"
+[[ -x "$patcherreport" ]] || { echo "<result></result>"; exit 0; }
+
+value=$("$patcherreport" get deadline.oldestPendingDays 2>/dev/null)
+
+echo "<result>${value:-0}</result>"

--- a/MDM Examples/Jamf Extension Attributes/tpp-patch-compliance-status.sh
+++ b/MDM Examples/Jamf Extension Attributes/tpp-patch-compliance-status.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Jamf Pro Extension Attribute — Third Party Patcher
+#   Display name : TPP - Patch Compliance Status
+#   Data type    : String
+#   Input type   : Script
+#
+# A single rollup verdict for the device, for dashboards and smart groups:
+#
+#   Not Installed        Third Party Patcher is not on this device
+#   Overdue              a hard deadline has been reached
+#   Deadline Approaching pending updates, hard deadline within 3 days
+#   Pending              updates staged, deadline not yet close
+#   Updates Detected     updates found but nothing staged yet
+#   Compliant            nothing outstanding
+#
+
+patcherreport="/usr/local/bin/tpp/patcherreport"
+[[ -x "$patcherreport" ]] || { echo "<result>Not Installed</result>"; exit 0; }
+
+pending=$("$patcherreport" get labelsPending 2>/dev/null)
+updateRequired=$("$patcherreport" get updateRequired 2>/dev/null)
+hardReached=$("$patcherreport" get deadline.hardDeadlineReached 2>/dev/null)
+daysToHard=$("$patcherreport" get deadline.daysUntilHardDeadline 2>/dev/null)
+
+pending=${pending:-0}
+updateRequired=${updateRequired:-0}
+
+status="Compliant"
+if [[ "$hardReached" == "true" ]]; then
+    status="Overdue"
+elif (( pending > 0 )) && [[ -n "$daysToHard" ]] && (( daysToHard <= 3 )); then
+    status="Deadline Approaching"
+elif (( pending > 0 )); then
+    status="Pending"
+elif (( updateRequired > 0 )); then
+    status="Updates Detected"
+fi
+
+echo "<result>${status}</result>"

--- a/MDM Examples/Jamf Extension Attributes/tpp-patching-mode.sh
+++ b/MDM Examples/Jamf Extension Attributes/tpp-patching-mode.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# Jamf Pro Extension Attribute — Third Party Patcher
+#   Display name : TPP - Patching Mode
+#   Data type    : String
+#   Input type   : Script
+#
+# "monthly" when a monthly patch-day cadence is configured, otherwise
+# "deadline". Blank if the tool is not installed.
+#
+
+patcherreport="/usr/local/bin/tpp/patcherreport"
+[[ -x "$patcherreport" ]] || { echo "<result></result>"; exit 0; }
+
+value=$("$patcherreport" get deadline.patchingMode 2>/dev/null)
+
+echo "<result>${value}</result>"

--- a/MDM Examples/Jamf Extension Attributes/tpp-pending-update-labels.sh
+++ b/MDM Examples/Jamf Extension Attributes/tpp-pending-update-labels.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# Jamf Pro Extension Attribute — Third Party Patcher
+#   Display name : TPP - Pending Update Labels
+#   Data type    : String
+#   Input type   : Script
+#
+# Comma-separated list of the Installomator labels that are staged and waiting
+# to be applied. Blank when nothing is pending.
+#
+
+patcherreport="/usr/local/bin/tpp/patcherreport"
+[[ -x "$patcherreport" ]] || { echo "<result></result>"; exit 0; }
+
+value=$("$patcherreport" pending --csv 2>/dev/null \
+        | tail -n +2 \
+        | cut -d, -f1 \
+        | paste -sd ',' - \
+        | sed 's/,/, /g')
+
+echo "<result>${value}</result>"

--- a/MDM Examples/Jamf Extension Attributes/tpp-pending-updates.sh
+++ b/MDM Examples/Jamf Extension Attributes/tpp-pending-updates.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Jamf Pro Extension Attribute — Third Party Patcher
+#   Display name : TPP - Pending Updates
+#   Data type    : Integer
+#   Input type   : Script
+#
+# Number of updates that are staged (downloaded) and waiting to be applied.
+#
+
+patcherreport="/usr/local/bin/tpp/patcherreport"
+[[ -x "$patcherreport" ]] || { echo "<result></result>"; exit 0; }
+
+value=$("$patcherreport" get labelsPending 2>/dev/null)
+
+echo "<result>${value:-0}</result>"

--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ The `patcherreport` binary generates compliance reports from local state files w
 
 `summary` and `pending` also report a deadline block (patching mode, oldest pending age, Focus/hard deadline dates, days remaining).
 
+Ready-to-use Jamf Pro Extension Attribute scripts built on `patcherreport get` are in
+[`MDM Examples/Jamf Extension Attributes/`](MDM%20Examples/Jamf%20Extension%20Attributes/).
+
 See the **[Reporting wiki page](../../wiki/Reporting)** for usage and output format.
 
 ---


### PR DESCRIPTION
Adds 12 ready-to-use Jamf Pro Extension Attribute scripts under `MDM Examples/Jamf Extension Attributes/`, built on the new `patcherreport get` subcommand (PR #22).

## Scripts

| Script | Data type | Reports |
|--------|-----------|---------|
| `tpp-last-scan.sh` | Date | Last full Installomator scan |
| `tpp-last-apply.sh` | Date | Last apply/install pass |
| `tpp-apps-requiring-update.sh` | Integer | Managed apps out of date |
| `tpp-pending-updates.sh` | Integer | Updates staged, awaiting apply |
| `tpp-oldest-pending-days.sh` | Integer | Age of oldest staged update |
| `tpp-days-until-hard-deadline.sh` | Integer | Days before deferrals are cut off |
| `tpp-broken-labels.sh` | Integer | Scan-broken + stage-broken labels |
| `tpp-deferrals-30-days.sh` | Integer | Dialog deferrals, last 30 days |
| `tpp-deadlines-forced.sh` | Integer | Times a hard deadline forced an install |
| `tpp-patching-mode.sh` | String | `monthly` or `deadline` |
| `tpp-pending-update-labels.sh` | String | Comma-separated staged label list |
| `tpp-patch-compliance-status.sh` | String | Rollup verdict |

## Notes

- Stock-macOS tools only — no `jq` / `python3`.
- Each script handles a missing binary gracefully (empty result, or `Not Installed` for the status EA).
- Date scripts convert `patcherreport`'s ISO-8601 output to Jamf's UTC `YYYY-MM-DD hh:mm:ss`.
- Directory `README.md` documents data types and Jamf setup steps.
- All 12 verified against a live install.

A companion wiki page (`Jamf-Extension-Attributes.md`) plus links from `Home.md` / `Reporting.md` are prepared separately for the wiki repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)