### PR TITLE
Add Intune macOS Custom Attribute scripts for patcherreport

### DIFF
--- a/MDM Examples/Intune Custom Attributes/README.md
+++ b/MDM Examples/Intune Custom Attributes/README.md
@@ -1,0 +1,87 @@
+# Intune Custom Attributes (macOS)
+
+Ready-to-use **Custom Attribute** shell scripts that pull Third Party Patcher
+status into Microsoft Intune device inventory. Each script shells out to
+`patcherreport` — mostly its `get` subcommand — and prints a single value.
+
+These are the Intune equivalents of the scripts in
+[`../Jamf Extension Attributes/`](../Jamf%20Extension%20Attributes/). The only
+differences: the output is the bare value (no `<result>` wrapper), and Date
+attributes are emitted in ISO-8601, which is what Intune expects.
+
+No `jq`, `python3`, or other add-ons are required.
+
+## Included scripts
+
+| Script | Attribute name | Data type | What it reports |
+|--------|----------------|-----------|----------------|
+| `tpp-last-scan.sh` | TPP - Last Scan | Date | Last full Installomator scan (ISO-8601, UTC) |
+| `tpp-last-apply.sh` | TPP - Last Apply | Date | Last apply/install pass (ISO-8601, UTC) |
+| `tpp-apps-requiring-update.sh` | TPP - Apps Requiring Update | Integer | Managed apps found out of date |
+| `tpp-pending-updates.sh` | TPP - Pending Updates | Integer | Updates staged and awaiting apply |
+| `tpp-oldest-pending-days.sh` | TPP - Oldest Pending Update (Days) | Integer | Age of the oldest staged update |
+| `tpp-days-until-hard-deadline.sh` | TPP - Days Until Hard Deadline | Integer | Days left before deferrals are cut off |
+| `tpp-broken-labels.sh` | TPP - Broken Labels | Integer | Scan-broken + stage-broken labels |
+| `tpp-deferrals-30-days.sh` | TPP - Deferrals (Last 30 Days) | Integer | Dialog deferrals in the last 30 days |
+| `tpp-deadlines-forced.sh` | TPP - Deadlines Forced (Lifetime) | Integer | Times a hard deadline forced an install |
+| `tpp-patching-mode.sh` | TPP - Patching Mode | String | `monthly` or `deadline` |
+| `tpp-pending-update-labels.sh` | TPP - Pending Update Labels | String | Comma-separated list of staged labels |
+| `tpp-patch-compliance-status.sh` | TPP - Patch Compliance Status | String | Rollup verdict (see below) |
+
+### Compliance status values
+
+`tpp-patch-compliance-status.sh` returns one of:
+
+| Value | Meaning |
+|-------|---------|
+| `Not Installed` | `patcherreport` is not present on the device |
+| `Overdue` | A hard deadline has been reached |
+| `Deadline Approaching` | Updates pending, hard deadline within 3 days |
+| `Pending` | Updates staged, deadline not yet close |
+| `Updates Detected` | Updates found but nothing staged yet |
+| `Compliant` | Nothing outstanding |
+
+## Adding a Custom Attribute to Intune
+
+1. In the [Intune admin center](https://intune.microsoft.com): **Devices ▸ macOS ▸
+   Custom attributes ▸ Add** (also reachable via *Manage devices ▸ Scripts and
+   remediations ▸ Platform scripts* on older tenants).
+2. **Basics** — give it a name (e.g. *TPP - Pending Updates*) and description.
+3. **Attributes** — choose the **Data type** from the table above and upload the
+   matching `.sh` file.
+4. **Scope tags** / **Assignments** — assign to the device groups you want.
+5. Save. Results appear per device under **Devices ▸ \<device\> ▸ Custom
+   attributes**, and can be exported or used in reporting.
+
+## Notes
+
+- **Run cadence is fixed.** Intune runs custom-attribute scripts about every
+  **8 hours**; there is no way to shorten it. Values are only as current as the
+  last run.
+- **Runs as root.** `patcherreport` only reads state files, but the scripts run
+  as root under Intune anyway.
+- **Binary path.** Scripts call `/usr/local/bin/tpp/patcherreport`. If you deploy
+  the dev build (`/usr/local/bin/tpp_dev/`), adjust the `patcherreport=` line.
+- **Dates.** Intune Date attributes must be ISO-8601; the date scripts pass
+  `patcherreport`'s output straight through (`2026-08-29T10:31:48Z`). Do not
+  reformat them.
+- **Empty output.** When a value isn't available (tool not installed, no active
+  deadline, never applied) the script prints an empty line. Integer scripts print
+  `0` instead where a zero is meaningful.
+- **Shell.** Scripts target `/bin/bash`, which is present on all supported macOS
+  releases.
+
+## Building your own
+
+`patcherreport get <dotted.key> [--from summary|pending|deferrals|broken|deadline]`
+prints any single scalar from the JSON payloads with no quoting or wrapping:
+
+```bash
+patcherreport get labelsNeverUpdated
+patcherreport get lastCheck.lastRun
+patcherreport get deadline.hardDeadlineReached
+patcherreport get totals.user --from deferrals --days 14
+```
+
+See the [Reporting wiki page](https://github.com/gilburns/Third-Party-Patcher/wiki/Reporting)
+for the full list of keys.

--- a/MDM Examples/Intune Custom Attributes/tpp-apps-requiring-update.sh
+++ b/MDM Examples/Intune Custom Attributes/tpp-apps-requiring-update.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Intune Custom Attribute (macOS) — Third Party Patcher
+#   Attribute name : TPP - Apps Requiring Update
+#   Data type      : Integer
+#
+# Number of managed apps the last check found to be out of date (whether or
+# not the update has been staged yet).
+#
+
+patcherreport="/usr/local/bin/tpp/patcherreport"
+[[ -x "$patcherreport" ]] || { echo ""; exit 0; }
+
+value=$("$patcherreport" get updateRequired 2>/dev/null)
+
+echo "${value:-0}"

--- a/MDM Examples/Intune Custom Attributes/tpp-broken-labels.sh
+++ b/MDM Examples/Intune Custom Attributes/tpp-broken-labels.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Intune Custom Attribute (macOS) — Third Party Patcher
+#   Attribute name : TPP - Broken Labels
+#   Data type      : Integer
+#
+# Combined count of scan-broken and stage-broken labels — labels that could
+# not be evaluated or repeatedly failed to download. See `patcherreport broken`
+# for the list.
+#
+
+patcherreport="/usr/local/bin/tpp/patcherreport"
+[[ -x "$patcherreport" ]] || { echo ""; exit 0; }
+
+scan=$("$patcherreport" get scanBrokenCount 2>/dev/null)
+stage=$("$patcherreport" get stageBrokenCount 2>/dev/null)
+
+echo "$(( ${scan:-0} + ${stage:-0} ))"

--- a/MDM Examples/Intune Custom Attributes/tpp-days-until-hard-deadline.sh
+++ b/MDM Examples/Intune Custom Attributes/tpp-days-until-hard-deadline.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# Intune Custom Attribute (macOS) — Third Party Patcher
+#   Attribute name : TPP - Days Until Hard Deadline
+#   Data type      : Integer
+#
+# Whole days from now until the hard deadline, after which no further
+# deferrals are allowed and the update is forced. Negative once the deadline
+# has passed. Blank when nothing is pending or DeadlineDaysHard is 0.
+#
+
+patcherreport="/usr/local/bin/tpp/patcherreport"
+[[ -x "$patcherreport" ]] || { echo ""; exit 0; }
+
+value=$("$patcherreport" get deadline.daysUntilHardDeadline 2>/dev/null)
+
+echo "${value}"

--- a/MDM Examples/Intune Custom Attributes/tpp-deadlines-forced.sh
+++ b/MDM Examples/Intune Custom Attributes/tpp-deadlines-forced.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Intune Custom Attribute (macOS) — Third Party Patcher
+#   Attribute name : TPP - Deadlines Forced (Lifetime)
+#   Data type      : Integer
+#
+# Number of times a hard deadline was reached and an update proceeded without
+# the user getting to choose. Counted across all recorded history.
+#
+
+patcherreport="/usr/local/bin/tpp/patcherreport"
+[[ -x "$patcherreport" ]] || { echo ""; exit 0; }
+
+value=$("$patcherreport" get totals.deadlinesForced --from deferrals 2>/dev/null)
+
+echo "${value:-0}"

--- a/MDM Examples/Intune Custom Attributes/tpp-deferrals-30-days.sh
+++ b/MDM Examples/Intune Custom Attributes/tpp-deferrals-30-days.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# Intune Custom Attribute (macOS) — Third Party Patcher
+#   Attribute name : TPP - Deferrals (Last 30 Days)
+#   Data type      : Integer
+#
+# Total dialog deferrals recorded in the last 30 days (user-chosen +
+# timer-timeout + blocking-process skips). A persistently high value flags a
+# device whose user keeps putting patching off.
+#
+
+patcherreport="/usr/local/bin/tpp/patcherreport"
+[[ -x "$patcherreport" ]] || { echo ""; exit 0; }
+
+value=$("$patcherreport" get totals.deferrals --from deferrals --days 30 2>/dev/null)
+
+echo "${value:-0}"

--- a/MDM Examples/Intune Custom Attributes/tpp-last-apply.sh
+++ b/MDM Examples/Intune Custom Attributes/tpp-last-apply.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# Intune Custom Attribute (macOS) — Third Party Patcher
+#   Attribute name : TPP - Last Apply
+#   Data type      : Date
+#
+# When the daemon last ran an apply (install) pass. Emitted in ISO-8601 (UTC),
+# the format Intune expects for a Date attribute. Blank if it has never
+# applied an update on this device.
+#
+
+patcherreport="/usr/local/bin/tpp/patcherreport"
+[[ -x "$patcherreport" ]] || { echo ""; exit 0; }
+
+value=$("$patcherreport" get lastApply.lastRun 2>/dev/null)
+
+echo "${value}"

--- a/MDM Examples/Intune Custom Attributes/tpp-last-scan.sh
+++ b/MDM Examples/Intune Custom Attributes/tpp-last-scan.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Intune Custom Attribute (macOS) — Third Party Patcher
+#   Attribute name : TPP - Last Scan
+#   Data type      : Date
+#
+# When the daemon last ran a full Installomator scan. Emitted in ISO-8601
+# (UTC), the format Intune expects for a Date attribute. Blank if unknown.
+#
+
+patcherreport="/usr/local/bin/tpp/patcherreport"
+[[ -x "$patcherreport" ]] || { echo ""; exit 0; }
+
+value=$("$patcherreport" get lastScan.lastRun 2>/dev/null)
+
+echo "${value}"

--- a/MDM Examples/Intune Custom Attributes/tpp-oldest-pending-days.sh
+++ b/MDM Examples/Intune Custom Attributes/tpp-oldest-pending-days.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# Intune Custom Attribute (macOS) — Third Party Patcher
+#   Attribute name : TPP - Oldest Pending Update (Days)
+#   Data type      : Integer
+#
+# Age in days of the oldest staged-but-not-applied update. 0 when nothing is
+# pending. Useful for device groups that escalate as machines approach the
+# deadline.
+#
+
+patcherreport="/usr/local/bin/tpp/patcherreport"
+[[ -x "$patcherreport" ]] || { echo ""; exit 0; }
+
+value=$("$patcherreport" get deadline.oldestPendingDays 2>/dev/null)
+
+echo "${value:-0}"

--- a/MDM Examples/Intune Custom Attributes/tpp-patch-compliance-status.sh
+++ b/MDM Examples/Intune Custom Attributes/tpp-patch-compliance-status.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Intune Custom Attribute (macOS) — Third Party Patcher
+#   Attribute name : TPP - Patch Compliance Status
+#   Data type      : String
+#
+# A single rollup verdict for the device, for reporting and device groups:
+#
+#   Not Installed        Third Party Patcher is not on this device
+#   Overdue              a hard deadline has been reached
+#   Deadline Approaching pending updates, hard deadline within 3 days
+#   Pending              updates staged, deadline not yet close
+#   Updates Detected     updates found but nothing staged yet
+#   Compliant            nothing outstanding
+#
+
+patcherreport="/usr/local/bin/tpp/patcherreport"
+[[ -x "$patcherreport" ]] || { echo "Not Installed"; exit 0; }
+
+pending=$("$patcherreport" get labelsPending 2>/dev/null)
+updateRequired=$("$patcherreport" get updateRequired 2>/dev/null)
+hardReached=$("$patcherreport" get deadline.hardDeadlineReached 2>/dev/null)
+daysToHard=$("$patcherreport" get deadline.daysUntilHardDeadline 2>/dev/null)
+
+pending=${pending:-0}
+updateRequired=${updateRequired:-0}
+
+status="Compliant"
+if [[ "$hardReached" == "true" ]]; then
+    status="Overdue"
+elif (( pending > 0 )) && [[ -n "$daysToHard" ]] && (( daysToHard <= 3 )); then
+    status="Deadline Approaching"
+elif (( pending > 0 )); then
+    status="Pending"
+elif (( updateRequired > 0 )); then
+    status="Updates Detected"
+fi
+
+echo "${status}"

--- a/MDM Examples/Intune Custom Attributes/tpp-patching-mode.sh
+++ b/MDM Examples/Intune Custom Attributes/tpp-patching-mode.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Intune Custom Attribute (macOS) — Third Party Patcher
+#   Attribute name : TPP - Patching Mode
+#   Data type      : String
+#
+# "monthly" when a monthly patch-day cadence is configured, otherwise
+# "deadline". Blank if the tool is not installed.
+#
+
+patcherreport="/usr/local/bin/tpp/patcherreport"
+[[ -x "$patcherreport" ]] || { echo ""; exit 0; }
+
+value=$("$patcherreport" get deadline.patchingMode 2>/dev/null)
+
+echo "${value}"

--- a/MDM Examples/Intune Custom Attributes/tpp-pending-update-labels.sh
+++ b/MDM Examples/Intune Custom Attributes/tpp-pending-update-labels.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Intune Custom Attribute (macOS) — Third Party Patcher
+#   Attribute name : TPP - Pending Update Labels
+#   Data type      : String
+#
+# Comma-separated list of the Installomator labels that are staged and waiting
+# to be applied. Blank when nothing is pending.
+#
+
+patcherreport="/usr/local/bin/tpp/patcherreport"
+[[ -x "$patcherreport" ]] || { echo ""; exit 0; }
+
+value=$("$patcherreport" pending --csv 2>/dev/null \
+        | tail -n +2 \
+        | cut -d, -f1 \
+        | paste -sd ',' - \
+        | sed 's/,/, /g')
+
+echo "${value}"

--- a/MDM Examples/Intune Custom Attributes/tpp-pending-updates.sh
+++ b/MDM Examples/Intune Custom Attributes/tpp-pending-updates.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Intune Custom Attribute (macOS) — Third Party Patcher
+#   Attribute name : TPP - Pending Updates
+#   Data type      : Integer
+#
+# Number of updates that are staged (downloaded) and waiting to be applied.
+#
+
+patcherreport="/usr/local/bin/tpp/patcherreport"
+[[ -x "$patcherreport" ]] || { echo ""; exit 0; }
+
+value=$("$patcherreport" get labelsPending 2>/dev/null)
+
+echo "${value:-0}"

--- a/README.md
+++ b/README.md
@@ -115,12 +115,13 @@ The `patcherreport` binary generates compliance reports from local state files w
 | `never-updated` | Apps with no successful apply on record |
 | `label` | Full chronological event history for one app |
 | `deferrals` | Audit log of every dialog interaction and user choice |
-| `get` | One scalar value from a report's JSON payload (for Jamf Extension Attributes) |
+| `get` | One scalar value from a report's JSON payload (for MDM inventory scripts) |
 
 `summary` and `pending` also report a deadline block (patching mode, oldest pending age, Focus/hard deadline dates, days remaining).
 
-Ready-to-use Jamf Pro Extension Attribute scripts built on `patcherreport get` are in
-[`MDM Examples/Jamf Extension Attributes/`](MDM%20Examples/Jamf%20Extension%20Attributes/).
+Ready-to-use inventory scripts built on `patcherreport get` are in `MDM Examples/`:
+[Jamf Extension Attributes](MDM%20Examples/Jamf%20Extension%20Attributes/) and
+[Intune Custom Attributes](MDM%20Examples/Intune%20Custom%20Attributes/).
 
 See the **[Reporting wiki page](../../wiki/Reporting)** for usage and output format.
 


### PR DESCRIPTION
Intune counterparts of the Jamf Extension Attribute scripts from #23, under `MDM Examples/Intune Custom Attributes/`.

Same 12 metrics, same logic. Differences from the Jamf set:

- Output is the bare value — no `<result></result>` wrapper.
- **Date** attributes are emitted as ISO-8601 (`2026-08-29T10:31:48Z`), which is what Intune's Date data type expects — no reformatting to `YYYY-MM-DD hh:mm:ss`.
- Directory `README.md` has Intune console steps and notes the fixed ~8-hour custom-attribute run cadence.

| Script | Data type |
|--------|-----------|
| `tpp-last-scan.sh` / `tpp-last-apply.sh` | Date |
| `tpp-apps-requiring-update.sh` | Integer |
| `tpp-pending-updates.sh` | Integer |
| `tpp-oldest-pending-days.sh` | Integer |
| `tpp-days-until-hard-deadline.sh` | Integer |
| `tpp-broken-labels.sh` | Integer |
| `tpp-deferrals-30-days.sh` | Integer |
| `tpp-deadlines-forced.sh` | Integer |
| `tpp-patching-mode.sh` | String |
| `tpp-pending-update-labels.sh` | String |
| `tpp-patch-compliance-status.sh` | String |

All 12 verified against a live install.

A companion wiki page (`Intune-Custom-Attributes.md`) plus `Home.md` / `Reporting.md` link updates are prepared separately for the wiki repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)